### PR TITLE
Errno::ESRCH for some cases of /proc/pid/environ

### DIFF
--- a/lib/linux/sys/proctable.rb
+++ b/lib/linux/sys/proctable.rb
@@ -134,8 +134,10 @@ module Sys
             key, value = str.split('=')
             struct.environ[key] = value
           }
-        rescue Errno::EACCES
+        rescue Errno::EACCES, Errno::ESRCH
           # Ignore and move on.
+        rescue IOError => ioe
+          raise unless ioe.message =~ /No such process/
         end
 
         # Get /proc/<pid>/exe information


### PR DESCRIPTION
Ruby 1.8.7 throws `Errno::ESRCH` when certain processes cannot be found through `/proc/pid/environ` (seen on `/proc/2/environ` on a CentOS 4.8 system), but the existing code only looks for `Errno::EACCES`. `Errno::EACCES` works if Ruby isn't running as `root`, but `Errno::ESRCH` is
thrown when root is the process owner.

I'm also catching `IOError` because of JRUBY-5959, but non-English locales could potentially mess this up, I guess.
