### PR TITLE
I think it makes sense to catch and ignore Errno::ENOENT

### DIFF
--- a/lib/linux/sys/proctable.rb
+++ b/lib/linux/sys/proctable.rb
@@ -134,7 +134,7 @@ module Sys
             key, value = str.split('=')
             struct.environ[key] = value
           }
-        rescue Errno::EACCES, Errno::ESRCH
+        rescue Errno::EACCES, Errno::ESRCH, Errno::ENOENT
           # Ignore and move on.
         end
 


### PR DESCRIPTION
Added Errno::ENOENT to proc IO.read. We were seeing this exception regularly for processes the simply check for other running processes every 5 seconds.    
