### PR TITLE
resuce when environ has invalid byte sequence.

### DIFF
--- a/lib/linux/sys/proctable.rb
+++ b/lib/linux/sys/proctable.rb
@@ -134,7 +134,7 @@ module Sys
             key, value = str.split('=')
             struct.environ[key] = value
           }
-        rescue Errno::EACCES, Errno::ESRCH, Errno::ENOENT
+        rescue Errno::EACCES, Errno::ESRCH, Errno::ENOENT, ArgumentError
           # Ignore and move on.
         end
 


### PR DESCRIPTION
This Pr is for this:

```
ArgumentError: invalid byte sequence in UTF-8
    from /usr/lib64/ruby/gems/2.1.0/gems/sys-proctable-0.9.4-universal-linux/lib/linux/sys/proctable.rb:134:in `split'
    from /usr/lib64/ruby/gems/2.1.0/gems/sys-proctable-0.9.4-universal-linux/lib/linux/sys/proctable.rb:134:in `block in ps'
    from /usr/lib64/ruby/gems/2.1.0/gems/sys-proctable-0.9.4-universal-linux/lib/linux/sys/proctable.rb:110:in `foreach'
    from /usr/lib64/ruby/gems/2.1.0/gems/sys-proctable-0.9.4-universal-linux/lib/linux/sys/proctable.rb:110:in `ps'
    from (irb):3
    from /usr/bin/irb:11:in `<main>'
```

The app that is causing it to freak out is dovecot in case you wanted to know. 
