### PR TITLE
Linux NLWP field (thread count)

### DIFF
--- a/lib/linux/sys/proctable.rb
+++ b/lib/linux/sys/proctable.rb
@@ -70,8 +70,9 @@ module Sys
       'euid',        # Effective user ID
       'gid',         # Real group ID
       'egid',        # Effective group ID
-      'pctcpu',     # Percent of CPU usage (custom field)
-      'pctmem'      # Percent of Memory usage (custom field)
+      'pctcpu',      # Percent of CPU usage (custom field)
+      'pctmem',      # Percent of Memory usage (custom field)
+      'nlwp'         # Number of Light-Weight Processes associated with the process (threads) 
     ]
 
     public
@@ -159,6 +160,10 @@ module Sys
 
         # Get /proc/<pid>/stat information
         stat = IO.read("/proc/#{file}/stat") rescue next
+
+        # Get number of LWP, one directory for each in /proc/<pid>/task/
+        # Every process has at least one thread, so if we fail to read the task directory, set nlwp to 1.
+        struct.nlwp = Dir.glob("/proc/#{file}/task/*").length rescue struct.nlwp = 1
 
         # Deal with spaces in comm name. Courtesy of Ara Howard.
         re = %r/\([^\)]+\)/

--- a/test/test_sys_proctable_linux.rb
+++ b/test/test_sys_proctable_linux.rb
@@ -17,7 +17,7 @@ class TC_ProcTable_Linux < Test::Unit::TestCase
       stime cutime cstime priority nice itrealvalue starttime vsize
       rss rlim startcode endcode startstack kstkesp kstkeip signal blocked
       sigignore sigcatch wchan nswap cnswap exit_signal processor environ
-      pctcpu pctmem
+      pctcpu pctmem nlwp
       /
   end
 
@@ -288,6 +288,11 @@ class TC_ProcTable_Linux < Test::Unit::TestCase
   def test_pctcpu
     assert_respond_to(@ptable, :pctcpu)
     assert_kind_of(Float, @ptable.pctcpu)
+  end
+
+  def test_nlwp
+    assert_respond_to(@ptable, :nlwp)
+    assert_kind_of(Fixnum, @ptable.nlwp)
   end
 
   def teardown


### PR DESCRIPTION
This PR implements a field on the Linux struct, ```:nlwp```, which shows the number of threads (light weight processes) running under a process. This value should be at least one for all processes. As an example of how this works, the collectd process on a test host has 11 threads running, as demonstrated by ```ps -eLf``` in the below output.

```
$ ps -eLf | grep 29441
root     29441 29439 29441  0   11  2013 ?        00:02:06 /opt/collectd/current/sbin/collectd -C /etc/collectd/collectd.conf -f
root     29441 29439 29442  0   11  2013 ?        00:08:14 /opt/collectd/current/sbin/collectd -C /etc/collectd/collectd.conf -f
root     29441 29439 29443  0   11  2013 ?        00:13:14 /opt/collectd/current/sbin/collectd -C /etc/collectd/collectd.conf -f
root     29441 29439 29444  0   11  2013 ?        00:10:02 /opt/collectd/current/sbin/collectd -C /etc/collectd/collectd.conf -f
root     29441 29439 29445  0   11  2013 ?        00:10:56 /opt/collectd/current/sbin/collectd -C /etc/collectd/collectd.conf -f
root     29441 29439 29446  0   11  2013 ?        00:10:41 /opt/collectd/current/sbin/collectd -C /etc/collectd/collectd.conf -f
root     29441 29439 29447  0   11  2013 ?        00:22:04 /opt/collectd/current/sbin/collectd -C /etc/collectd/collectd.conf -f
root     29441 29439 29448  0   11  2013 ?        00:17:05 /opt/collectd/current/sbin/collectd -C /etc/collectd/collectd.conf -f
root     29441 29439 29449  0   11  2013 ?        00:17:47 /opt/collectd/current/sbin/collectd -C /etc/collectd/collectd.conf -f
root     29441 29439 29450  0   11  2013 ?        00:21:15 /opt/collectd/current/sbin/collectd -C /etc/collectd/collectd.conf -f
root     29441 29439 29451  0   11  2013 ?        00:00:00 /opt/collectd/current/sbin/collectd -C /etc/collectd/collectd.conf -f
1087     30439 20296 30439  0    1 16:58 pts/1    00:00:00 grep 29441
```

The nlwp field of the process' struct correctly reports 11 LWPs belong to that process.

```
2.1.0 :002 > Sys::ProcTable.ps(29441).nlwp
 => 11
```