### PR TITLE
Add support for cgroup

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -156,7 +156,7 @@ namespace :gem do
       when /linux/i
          spec.platform = Gem::Platform.new(['universal', 'linux'])
          spec.require_paths = ['lib', 'lib/linux']
-         spec.files += ['lib/linux/sys/proctable.rb']
+         spec.files += ['lib/linux/sys/proctable.rb', 'lib/linux/sys/cgroup_entry.rb']
          spec.test_files << 'test/test_sys_proctable_linux.rb'
       when /sunos|solaris/i
          spec.platform = Gem::Platform.new(['universal', 'solaris'])

--- a/lib/linux/sys/cgroup_entry.rb
+++ b/lib/linux/sys/cgroup_entry.rb
@@ -1,0 +1,48 @@
+module Sys
+  # This represents a cgroup entry
+  #
+  # Have a look at `man 5 proc` on a linux distribution, to get some more
+  # information about the lines and there fields in `/proc/[pid]/cgroup`.
+  #
+  # Example:
+  #
+  #   entry = CgroupEntry.new '7:devices:/init.scope'
+  #   entry.hierarchy_id  # => 7
+  #   entry.subsystems    # => ['devices']
+  #   entry.control_group # => '/init.scope'
+  #
+  class CgroupEntry
+    # Create a new cgroup entry object
+    #
+    # This expects a string of '7:devices:/init.scope' - see `man 5 proc` for a
+    # reference.
+    def initialize(string)
+      @string = string.chomp
+      @fields = @string.split(/:/)
+    rescue
+      @fields = []
+    end
+
+    # This returns the hierarchy id of the cgroup entry
+    def hierarchy_id
+      @fields[0].to_i
+    end
+
+    # Return sets of subsystems bound to the hierarchy
+    def subsystems
+      @fields[1].split(/,/)
+    rescue
+      []
+    end
+
+    # control group in the hierarchy to which the process belongs
+    def control_group
+      @fields[2]
+    end
+
+    # Return the line itself
+    def to_s
+      @string
+    end
+  end
+end

--- a/lib/linux/sys/proctable.rb
+++ b/lib/linux/sys/proctable.rb
@@ -1,4 +1,5 @@
 require 'sys/proctable/version'
+require 'linux/sys/cgroup_entry'
 
 # The Sys module serves as a namespace only.
 module Sys
@@ -71,7 +72,8 @@ module Sys
       'egid',        # Effective group ID
       'pctcpu',      # Percent of CPU usage (custom field)
       'pctmem',      # Percent of Memory usage (custom field)
-      'nlwp'         # Number of Light-Weight Processes associated with the process (threads) 
+      'nlwp',        # Number of Light-Weight Processes associated with the process (threads) 
+      'cgroup'       # Control groups to which the process belongs
     ]
 
     public
@@ -163,6 +165,9 @@ module Sys
         # Get number of LWP, one directory for each in /proc/<pid>/task/
         # Every process has at least one thread, so if we fail to read the task directory, set nlwp to 1.
         struct.nlwp = Dir.glob("/proc/#{file}/task/*").length rescue struct.nlwp = 1
+
+        # Get control groups to which the process belongs
+        struct.cgroup = IO.readlines("/proc/#{file}/cgroup").map { |l| CgroupEntry.new(l) } rescue []
 
         # Deal with spaces in comm name. Courtesy of Ara Howard.
         re = %r/\([^\)]+\)/

--- a/test/test_sys_proctable_linux.rb
+++ b/test/test_sys_proctable_linux.rb
@@ -17,7 +17,7 @@ class TC_ProcTable_Linux < Test::Unit::TestCase
       stime cutime cstime priority nice itrealvalue starttime vsize
       rss rlim startcode endcode startstack kstkesp kstkeip signal blocked
       sigignore sigcatch wchan nswap cnswap exit_signal processor environ
-      pctcpu pctmem nlwp
+      pctcpu pctmem nlwp cgroup
       /
   end
 
@@ -293,6 +293,12 @@ class TC_ProcTable_Linux < Test::Unit::TestCase
   def test_nlwp
     assert_respond_to(@ptable, :nlwp)
     assert_kind_of(Fixnum, @ptable.nlwp)
+  end
+
+  def test_cgroup
+    assert_respond_to(@ptable, :cgroup)
+    assert_kind_of(Array, @ptable.cgroup)
+    assert_kind_of(CgroupEntry, @ptable.cgroup.first)
   end
 
   def teardown


### PR DESCRIPTION
@djberg96 I need to parse the cgroups of a process. This PR adds this functionality. It uses `/proc/[PID]/cgroup` for that. Each line of this file is represented by a `CgroupEntry`. I used information from [`man 5 proc`](http://man7.org/linux/man-pages/man5/proc.5.html) to define the methods of a `CgroupEntry`.

~~~ruby
p = Sys::ProcTable.ps(1)
entry = p.cgroup.first
puts entry.hierarchy_id    # => 8
puts entry.subsystems      # => ['freezer']
puts entry.control_group   # => '/'
~~~

If you like that changes: Would it be possible to release a new gem version in the next couple of days? I would like to use this functionality to create a monitoring script for docker containers - at least I hope so. Thanks a lot.

Cheers
Dennis