### PR TITLE
Improved process parsing under Linux & OSX

### DIFF
--- a/lib/darwin/sys/proctable.rb
+++ b/lib/darwin/sys/proctable.rb
@@ -112,7 +112,7 @@ module Sys
       virtual_size resident_size total_user total_system threads_user
       threads_system policy faults pageins cow_faults messages_sent
       messages_received syscalls_mach syscalls_unix csw threadnum numrunning
-      priority cmdline exe arguments environ threadinfo
+      priority cmdline exe pname arguments environ threadinfo
     ]
 
     # Add a couple aliases to make it similar to Linux
@@ -327,15 +327,19 @@ module Sys
           # Everything else is an argument
           if struct[:exe].nil?
             struct[:exe] = str
-          elsif struct[:name].nil?
-            struct[:name] = str
+          elsif struct[:pname].nil?
+            struct[:pname] = str
           else
             struct[:arguments] << str
           end
         end
       end
 
-      struct[:cmdline] = struct[:name] + ' ' + struct[:arguments].join(' ')
+      if struct[:arguments].empty?
+        struct[:cmdline] = struct[:pname]
+      else
+        struct[:cmdline] = struct[:pname] + ' ' + struct[:arguments].join(' ')
+      end
       struct[:environ] = environment
     end
   end

--- a/lib/linux/sys/proctable.rb
+++ b/lib/linux/sys/proctable.rb
@@ -67,6 +67,7 @@ module Sys
       'rt_priority', # Real time scheduling priority
       'policy',      # Scheduling policy
       'name',        # Process name
+      'arguments',   # Process arguments
       'uid',         # Real user ID
       'euid',        # Effective user ID
       'gid',         # Real group ID
@@ -117,10 +118,12 @@ module Sys
 
         struct = ProcTableStruct.new
 
-        # Get /proc/<pid>/cmdline information. Strip out embedded nulls.
+        # Get /proc/<pid>/cmdline information. Split on null byte
         begin
-          data = IO.read("/proc/#{file}/cmdline").tr("\000", ' ').strip
-          struct.cmdline = data
+          data = IO.read("/proc/#{file}/cmdline").split(?\x00)
+          struct.name = data.shift
+          struct.arguments = data
+          struct.cmdline = struct.name + ' ' + data.join(' ')
         rescue
           next # Process terminated, on to the next process
         end

--- a/test/test_sys_proctable_darwin.rb
+++ b/test/test_sys_proctable_darwin.rb
@@ -16,7 +16,7 @@ class TC_ProcTable_Darwin < Test::Unit::TestCase
       virtual_size resident_size total_user total_system threads_user
       threads_system policy faults pageins cow_faults messages_sent
       messages_received syscalls_mach syscalls_unix csw threadnum numrunning
-      priority cmdline exe arguments environ threadinfo
+      priority cmdline exe pname arguments environ threadinfo
     ]
 
     @@pid = fork do

--- a/test/test_sys_proctable_darwin.rb
+++ b/test/test_sys_proctable_darwin.rb
@@ -16,7 +16,7 @@ class TC_ProcTable_Darwin < Test::Unit::TestCase
       virtual_size resident_size total_user total_system threads_user
       threads_system policy faults pageins cow_faults messages_sent
       messages_received syscalls_mach syscalls_unix csw threadnum numrunning
-      priority cmdline exe environ threadinfo
+      priority cmdline exe arguments environ threadinfo
     ]
 
     @@pid = fork do
@@ -101,10 +101,22 @@ class TC_ProcTable_Darwin < Test::Unit::TestCase
     assert_equal('ruby -Ilib -e sleep \'120\'.to_i -- foo bar', @ptable2.cmdline)
   end
 
+  test "name struct member is defined and returns expected value" do
+    assert_respond_to(@ptable, :name)
+    assert_kind_of(String, @ptable2.name)
+    assert_equal("ruby", @ptable2.name)
+  end
+
   test "exe struct member is defined and returns expected value" do
     assert_respond_to(@ptable, :exe)
     assert_kind_of(String, @ptable.exe)
     assert_equal(`which sleep`.chomp, @ptable.exe)
+  end
+
+  test "arguments struct member is defined and returns expected value" do
+    assert_respond_to(@ptable, :arguments)
+    assert_kind_of(Array, @ptable2.arguments)
+    assert_equal(["-Ilib", "-e", "sleep '120'.to_i", "--", "foo bar"], @ptable2.arguments)
   end
 
   test "environ struct member is defined and returns expected value" do

--- a/test/test_sys_proctable_linux.rb
+++ b/test/test_sys_proctable_linux.rb
@@ -12,7 +12,7 @@ include Sys
 class TC_ProcTable_Linux < Test::Unit::TestCase
   def self.startup
     @@fields = %w/
-      cmdline cwd exe pid name uid euid gid egid comm state ppid pgrp
+      cmdline cwd exe pid name arguments uid euid gid egid comm state ppid pgrp
       session tty_num tpgid flags minflt cminflt majflt cmajflt utime
       stime cutime cstime priority nice itrealvalue starttime vsize
       rss rlim startcode endcode startstack kstkesp kstkeip signal blocked
@@ -258,6 +258,11 @@ class TC_ProcTable_Linux < Test::Unit::TestCase
   def test_name
     assert_respond_to(@ptable, :name)
     assert_kind_of(String, @ptable.name)
+  end
+
+  def test_arguments
+    assert_respond_to(@ptable, :arguments)
+    assert_kind_of(Array, @ptable.arguments)
   end
 
   def test_uid

--- a/test/test_sys_proctable_linux.rb
+++ b/test/test_sys_proctable_linux.rb
@@ -12,7 +12,7 @@ include Sys
 class TC_ProcTable_Linux < Test::Unit::TestCase
   def self.startup
     @@fields = %w/
-      cmdline cwd exe pid name arguments uid euid gid egid comm state ppid pgrp
+      cmdline cwd exe pid name pname arguments uid euid gid egid comm state ppid pgrp
       session tty_num tpgid flags minflt cminflt majflt cmajflt utime
       stime cutime cstime priority nice itrealvalue starttime vsize
       rss rlim startcode endcode startstack kstkesp kstkeip signal blocked


### PR DESCRIPTION
To identify processes properly/consistently across software & languages, it's necessary to know the know the process name and it's arguments.  Currently, sys-proctable provides the process name and arguments as a reconstituted string (`cmdline`) which doesn't make it possible to determine exactly where name ends and arguments start.  (It's not not always based on whitespace)

On Linux, this is determined by the position of null bytes in `/proc/x/cmdline`.  On OSX, you documented the partitioning [here](https://github.com/djberg96/sys-proctable/blob/master/lib/darwin/sys/proctable.rb#L307-L314).

This PR preserves and exposes this partitioning for Linux & OSX.

- Add `pname` to fields (to distinguish from `name` derived from `/proc/x/status`)
- Add `arguments` to fields
- Improved process name & arguments parsing for Linux & OSX
- Update & add tests to follow changes

Our related issue/PR: https://github.com/instana/ruby-sensor/pull/74