### PR TITLE
Add bench_ips_ps script

### DIFF
--- a/benchmarks/bench_ips_ps
+++ b/benchmarks/bench_ips_ps
@@ -1,0 +1,63 @@
+#!/usr/bin/env ruby
+
+require 'json'
+require 'optparse'
+require 'rbconfig'
+require 'benchmark/ips'
+
+@source, @gem = false
+
+OptionParser.new do |opt|
+  opt.banner = "Usage: #{File.basename $0} [--gem|--source]"
+
+  opt.separator ""
+  opt.separator "Benchmark IPS (iterations per second) changes between"
+  opt.separator "source version of sys-proctable and previous gem"
+  opt.separator "version."
+  opt.separator ""
+  opt.separator "Requires that the both the source version of the gem"
+  opt.separator "be installed (run `rake install` to do this after"
+  opt.separator "each of your changes) and version installed via"
+  opt.separator "rubygems."
+  opt.separator ""
+  opt.separator "To run, call with `--gem` two times, and then with "
+  opt.separator "`--source` two times again."
+  opt.separator ""
+
+  opt.on("--source") { @source = true }
+  opt.on("--gem")    { @gem = true }
+end.parse!
+
+if @source && !@gem
+  # Being paranoid here and making sure we get the version installed to
+  # sitelibdir
+  require File.join(RbConfig::CONFIG["sitelibdir"], "sys", "proctable")
+else
+  @gem = true
+  require 'sys-proctable'
+end
+
+Benchmark.ips do |bench|
+  bench.report("Block form - pre patch") do
+    (puts "ERR:  Please run with --gem"; exit 1) unless @gem
+    Sys::ProcTable.ps {}
+  end
+
+  bench.report("Non-block form - pre patch") do
+    (puts "ERR:  Please run with --gem"; exit 1) unless @gem
+    Sys::ProcTable.ps
+  end
+
+  bench.report("Block form - post patch") do
+    (puts "ERR:  Please run with --source"; exit 1) unless @source
+    Sys::ProcTable.ps {}
+  end
+
+  bench.report("Non-block form - post patch") do
+    (puts "ERR:  Please run with --source"; exit 1) unless @source
+    Sys::ProcTable.ps
+  end
+
+  bench.hold! "bench_ips_ps.results"
+  bench.compare!
+end


### PR DESCRIPTION
Used this to test changes before and after to compare the number of iterations per second a particular change had an effect on with `.ps` being run.  Similar to the existing benchmarks/bench_ps.rb script, but basically duplicates the runs, and labels 2 for the original, and two for the source.

Sample invocation/usage:
------------------------

```
$ bench/bench_ips_ps --gem
$ bench/bench_ips_ps --gem
$ bench/bench_ips_ps --source
$ bench/bench_ips_ps --source
```

Comparison results will be shown after the last run.  Do to limitations in the benchmarks/ips hold functionality, this was the best way to run this.

Example results can be found in the "Benchmarks" of the https://github.com/djberg96/sys-proctable/pull/66 description (Note:  The output was munged together by hand though, to make it easier to digest by the reader).