### PR TITLE
[Darwin] Change strategy for single pid versus all pids

### DIFF
--- a/lib/darwin/sys/proctable.rb
+++ b/lib/darwin/sys/proctable.rb
@@ -172,10 +172,31 @@ module Sys
     #   # Same as above, but do not include thread information
     #   p ProcTable.ps(pid: 1001, thread_info: false)
     #
-    def self.ps(**kwargs)
+    def self.ps(**kwargs, &block)
       pid = kwargs[:pid]
       raise TypeError unless pid.is_a?(Numeric) if pid
+      pid ? get_info_for_pid(pid, kwargs, &block) : get_info_for_all_pids(kwargs, &block)
+    end
 
+    private
+
+    def self.get_info_for_pid(pid, **kwargs)
+      info = get_proc_task_info(pid)
+      return if info.nil?
+
+      struct = ProcTableStruct.new
+
+      # Pass by reference
+      get_cmd_args_and_env(pid, struct)
+      get_thread_info(pid, struct, info[:ptinfo]) unless kwargs[:thread_info] == false
+      apply_info_to_struct(info, struct)
+
+      struct.freeze
+      yield struct if block_given?
+      struct
+    end
+
+    def self.get_info_for_all_pids(**kwargs)
       num = proc_listallpids(nil, 0)
       ptr = FFI::MemoryPointer.new(:pid_t, num)
       num = proc_listallpids(ptr, ptr.size)
@@ -186,19 +207,8 @@ module Sys
       array = block_given? ? nil : []
 
       pids.each do |lpid|
-        next unless pid == lpid if pid
-        info = get_proc_task_info(pid)
-        next if info.nil?
-
-        struct = ProcTableStruct.new
-
-        # Pass by reference
-        get_cmd_args_and_env(lpid, struct)
-        get_thread_info(lpid, struct, info[:ptinfo]) unless kwargs[:thread_info] == false
-        apply_info_to_struct(info, struct)
-
-
-        struct.freeze
+        struct = get_info_for_pid(lpid, kwargs)
+        next if struct.nil?
 
         if block_given?
           yield struct
@@ -208,10 +218,8 @@ module Sys
       end
 
       return nil if array.nil?
-      pid ? array.first : array
+      array
     end
-
-    private
 
     def self.get_proc_task_info(pid)
       raise TypeError unless pid.is_a?(Numeric)

--- a/lib/darwin/sys/proctable.rb
+++ b/lib/darwin/sys/proctable.rb
@@ -207,17 +207,8 @@ module Sys
         # Pass by reference
         get_cmd_args_and_env(lpid, struct)
         get_thread_info(lpid, struct, info[:ptinfo]) unless kwargs[:thread_info] == false
+        apply_info_to_struct(info, struct)
 
-        # Chop the leading xx_ from the FFI struct members for our ruby struct.
-        info.members.each do |nested|
-          info[nested].members.each do |member|
-            if info[nested][member].is_a?(FFI::StructLayout::CharArray)
-              struct[PROC_STRUCT_FIELD_MAP[member]] = info[nested][member].to_s
-            else
-              struct[PROC_STRUCT_FIELD_MAP[member]] = info[nested][member]
-            end
-          end
-        end
 
         struct.freeze
 
@@ -233,6 +224,19 @@ module Sys
     end
 
     private
+
+    def self.apply_info_to_struct(info, struct)
+      # Chop the leading xx_ from the FFI struct members for our ruby struct.
+      info.members.each do |nested|
+        info[nested].members.each do |member|
+          if info[nested][member].is_a?(FFI::StructLayout::CharArray)
+            struct[PROC_STRUCT_FIELD_MAP[member]] = info[nested][member].to_s
+          else
+            struct[PROC_STRUCT_FIELD_MAP[member]] = info[nested][member]
+          end
+        end
+      end
+    end
 
     # Returns an array of ThreadInfo objects for the given pid.
     #


### PR DESCRIPTION
Changes:

- Makes helper methods for core pieces of the original `.ps` method
- Simplifies the action of `Sys::ProcTable.ps` to be a ternary that choose between two helper methods.

The new flow of this ternary in `Sys::ProcTable.ps` can be described as follows:

- If the method has a `pid` passed in, it will call `get_info_for_pid`, with the `pid` as the argument (and a block, if there is one)
- If the `pid` value is `nil`, then the `get_info_for_all_pids` method will be called, and `get_info_for_pid` will be called for each `pid` that it finds.  Block evaluation is the same as it was before, and running with a block won't add the struct to the array.

That said, the changes here have a very minimal impact to performance, if any.

Extracted from https://github.com/djberg96/sys-proctable/pull/65