### PR TITLE
README and CHANGELOG changes for 1.2.0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 == 1.2.0 - 20-Feb-2018
 * There has been an API change. The ProcTable.ps method now uses keyword
   arguments. The 'pid' option is universal, the rest depend on the platform.
+  As part of this change, support for Ruby < 2.0 has been dropped.
 * Support for HP-UX has been dropped, both because it was the last remaining
   platform that still used C code, and because it's basically a dead platform.
 * There are no more platform-specific gems. There is now a single gem that

--- a/README
+++ b/README
@@ -9,7 +9,6 @@
 * Linux 2.6+
 * FreeBSD
 * Solaris 8+
-* HP-UX 10+
 * OS X 10.7+
 * AIX 5.3+
 
@@ -77,7 +76,6 @@
 
 == Future Plans
   Add support for NetBSD and OpenBSD.
-  Convert remaining C code (just HP-UX at this point) to FFI.
 
 == Acknowledgements
   This library was originally based on the Perl module Proc::ProcessTable

--- a/README
+++ b/README
@@ -2,7 +2,7 @@
   A Ruby interface for gathering process information.
 
 == Prerequisites
-* Test::Unit 2.x (development only)
+* RSpec 3.x (development only)
 
 == Supported Platforms
 * Windows 2000 or later


### PR DESCRIPTION
Makes some important mentions and changes to the `README` and `CHANGELOG` after the changes for 1.2.0:

* No longer support Ruby < 2.0
* HP-UX no longer should be mentioned in the `README`
* Make sure we are mentioning the use of `rspec` and not `test/unit` for testing now.