### PR TITLE
Add num_threads field, update specs

### DIFF
--- a/lib/linux/sys/proctable.rb
+++ b/lib/linux/sys/proctable.rb
@@ -45,6 +45,7 @@ module Sys
       'cstime',      # Number of children's kernel mode jiffies
       'priority',    # Nice value plus 15
       'nice',        # Nice value
+      'num_threads', # Number of threads in this process
       'itrealvalue', # Time in jiffies before next SIGALRM
       'starttime',   # Time in jiffies since system boot
       'vsize',       # Virtual memory size in bytes
@@ -216,7 +217,7 @@ module Sys
         struct.cstime      = stat[16].to_i
         struct.priority    = stat[17].to_i
         struct.nice        = stat[18].to_i
-        # Skip 19
+        struct.num_threads = stat[19].to_i
         struct.itrealvalue = stat[20].to_i
         struct.starttime   = stat[21].to_i
         struct.vsize       = stat[22].to_i

--- a/spec/sys_proctable_linux_spec.rb
+++ b/spec/sys_proctable_linux_spec.rb
@@ -10,12 +10,12 @@ require_relative 'sys_proctable_all_spec'
 
 describe Sys::ProcTable do
   let(:fields){ %w[
-      cmdline cwd exe pid name uid euid gid egid comm state ppid pgrp
-      session tty_num tpgid flags minflt cminflt majflt cmajflt utime
-      stime cutime cstime priority nice itrealvalue starttime vsize
+      cmdline cwd environ exe fd root pid name uid euid gid egid comm state ppid pgrp
+      session tty_nr tpgid flags minflt cminflt majflt cmajflt utime
+      stime cutime cstime priority nice num_threads itrealvalue starttime vsize
       rss rlim startcode endcode startstack kstkesp kstkeip signal blocked
-      sigignore sigcatch wchan nswap cnswap exit_signal processor environ
-      pctcpu pctmem nlwp cgroup smaps
+      sigignore sigcatch wchan nswap cnswap exit_signal processor rt_priority
+      policy pctcpu pctmem nlwp cgroup smaps
     ]
   }
 
@@ -145,6 +145,11 @@ describe Sys::ProcTable do
     it "contains a nice member and returns the expected value" do
       expect(subject).to respond_to(:nice)
       expect(subject.nice).to be_kind_of(Numeric)
+    end
+
+    it "contains a num_threads member and returns the expected value" do
+      expect(subject).to respond_to(:num_threads)
+      expect(subject.num_threads).to be_kind_of(Numeric)
     end
 
     it "contains a itrealvalue member and returns the expected value" do
@@ -305,6 +310,14 @@ describe Sys::ProcTable do
     it "contains a smaps member and returns the expected value" do
       expect(subject).to respond_to(:cgroup)
       expect(subject.smaps).to be_kind_of(Sys::ProcTable::Smaps)
+    end
+  end
+
+  context "fields" do
+    it "has a fields method that returns the expected results" do
+      expect(described_class).to respond_to(:fields)
+      expect(described_class.fields).to be_kind_of(Array)
+      expect(described_class.fields).to match_array(fields)
     end
   end
 end


### PR DESCRIPTION
In kernels prior to Linux 2.6, the "num_threads" field was hard-coded to 0 as a placeholder. This library was originally written before 2.6 came out, but I never updated it once Linux updated this field to hold a meaningful value.

I also noticed that I didn't have any specs for the `fields` method, so I added those.