### PR TITLE
Update rsslim field, add more fields

### DIFF
--- a/lib/linux/sys/proctable.rb
+++ b/lib/linux/sys/proctable.rb
@@ -50,7 +50,8 @@ module Sys
       'starttime',   # Time in jiffies since system boot
       'vsize',       # Virtual memory size in bytes
       'rss',         # Resident set size
-      'rlim',        # Current limit on the rss in bytes
+      'rlim',        # Current limit on the rss in bytes (old)
+      'rsslim',      # Current limit on the rss in bytes (current)
       'startcode',   # Address above which program text can run
       'endcode',     # Address below which program text can run
       'startstack',  # Address of the startstack
@@ -222,7 +223,8 @@ module Sys
         struct.starttime   = stat[21].to_i
         struct.vsize       = stat[22].to_i
         struct.rss         = stat[23].to_i
-        struct.rlim        = stat[24].to_i
+        struct.rlim        = stat[24].to_i # Old name for backwards compatibility
+        struct.rsslim      = stat[24].to_i
         struct.startcode   = stat[25].to_i
         struct.endcode     = stat[26].to_i
         struct.startstack  = stat[27].to_i

--- a/lib/linux/sys/proctable.rb
+++ b/lib/linux/sys/proctable.rb
@@ -20,64 +20,67 @@ module Sys
     @boot_time = IO.read("/proc/stat")[/btime.*/].split.last.to_i rescue nil
 
     @fields = [
-      'cmdline',     # Complete command line
-      'cwd',         # Current working directory
-      'environ',     # Environment
-      'exe',         # Actual pathname of the executed command
-      'fd',          # File descriptors open by process
-      'root',        # Root directory of process
-      'pid',         # Process ID
-      'comm',        # Filename of executable
-      'state',       # Single character state abbreviation
-      'ppid',        # Parent process ID
-      'pgrp',        # Process group
-      'session',     # Session ID
-      'tty_nr',      # TTY (terminal) associated with the process
-      'tpgid',       # Group ID of the TTY
-      'flags',       # Kernel flags
-      'minflt',      # Number of minor faults
-      'cminflt',     # Number of minor faults of waited-for children
-      'majflt',      # Number of major faults
-      'cmajflt',     # Number of major faults of waited-for children
-      'utime',       # Number of user mode jiffies
-      'stime',       # Number of kernel mode jiffies
-      'cutime',      # Number of children's user mode jiffies
-      'cstime',      # Number of children's kernel mode jiffies
-      'priority',    # Nice value plus 15
-      'nice',        # Nice value
-      'num_threads', # Number of threads in this process
-      'itrealvalue', # Time in jiffies before next SIGALRM
-      'starttime',   # Time in jiffies since system boot
-      'vsize',       # Virtual memory size in bytes
-      'rss',         # Resident set size
-      'rlim',        # Current limit on the rss in bytes (old)
-      'rsslim',      # Current limit on the rss in bytes (current)
-      'startcode',   # Address above which program text can run
-      'endcode',     # Address below which program text can run
-      'startstack',  # Address of the startstack
-      'kstkesp',     # Kernel stack page address
-      'kstkeip',     # Kernel instruction pointer
-      'signal',      # Bitmap of pending signals
-      'blocked',     # Bitmap of blocked signals
-      'sigignore',   # Bitmap of ignored signals
-      'sigcatch',    # Bitmap of caught signals
-      'wchan',       # Channel in which the process is waiting
-      'nswap',       # Number of pages swapped
-      'cnswap',      # Cumulative nswap for child processes
-      'exit_signal', # Signal to be sent to parent when process dies
-      'processor',   # CPU number last executed on
-      'rt_priority', # Real time scheduling priority
-      'policy',      # Scheduling policy
-      'name',        # Process name
-      'uid',         # Real user ID
-      'euid',        # Effective user ID
-      'gid',         # Real group ID
-      'egid',        # Effective group ID
-      'pctcpu',      # Percent of CPU usage (custom field)
-      'pctmem',      # Percent of Memory usage (custom field)
-      'nlwp',        # Number of Light-Weight Processes associated with the process (threads)
-      'cgroup',      # Control groups to which the process belongs
-      'smaps'        # Process memory size for all mapped files
+      'cmdline',               # Complete command line
+      'cwd',                   # Current working directory
+      'environ',               # Environment
+      'exe',                   # Actual pathname of the executed command
+      'fd',                    # File descriptors open by process
+      'root',                  # Root directory of process
+      'pid',                   # Process ID
+      'comm',                  # Filename of executable
+      'state',                 # Single character state abbreviation
+      'ppid',                  # Parent process ID
+      'pgrp',                  # Process group
+      'session',               # Session ID
+      'tty_nr',                # TTY (terminal) associated with the process
+      'tpgid',                 # Group ID of the TTY
+      'flags',                 # Kernel flags
+      'minflt',                # Number of minor faults
+      'cminflt',               # Number of minor faults of waited-for children
+      'majflt',                # Number of major faults
+      'cmajflt',               # Number of major faults of waited-for children
+      'utime',                 # Number of user mode jiffies
+      'stime',                 # Number of kernel mode jiffies
+      'cutime',                # Number of children's user mode jiffies
+      'cstime',                # Number of children's kernel mode jiffies
+      'priority',              # Nice value plus 15
+      'nice',                  # Nice value
+      'num_threads',           # Number of threads in this process
+      'itrealvalue',           # Time in jiffies before next SIGALRM
+      'starttime',             # Time in jiffies since system boot
+      'vsize',                 # Virtual memory size in bytes
+      'rss',                   # Resident set size
+      'rlim',                  # Current limit on the rss in bytes (old)
+      'rsslim',                # Current limit on the rss in bytes (current)
+      'startcode',             # Address above which program text can run
+      'endcode',               # Address below which program text can run
+      'startstack',            # Address of the startstack
+      'kstkesp',               # Kernel stack page address
+      'kstkeip',               # Kernel instruction pointer
+      'signal',                # Bitmap of pending signals
+      'blocked',               # Bitmap of blocked signals
+      'sigignore',             # Bitmap of ignored signals
+      'sigcatch',              # Bitmap of caught signals
+      'wchan',                 # Channel in which the process is waiting
+      'nswap',                 # Number of pages swapped
+      'cnswap',                # Cumulative nswap for child processes
+      'exit_signal',           # Signal to be sent to parent when process dies
+      'processor',             # CPU number last executed on
+      'rt_priority',           # Real time scheduling priority
+      'policy',                # Scheduling policy
+      'delayacct_blkio_ticks', # Aggregated block I/O delays
+      'guest_time',            # Guest time of the process
+      'cguest_time',           # Guest time of the process's children
+      'name',                  # Process name
+      'uid',                   # Real user ID
+      'euid',                  # Effective user ID
+      'gid',                   # Real group ID
+      'egid',                  # Effective group ID
+      'pctcpu',                # Percent of CPU usage (custom field)
+      'pctmem',                # Percent of Memory usage (custom field)
+      'nlwp',                  # Number of Light-Weight Processes associated with the process (threads)
+      'cgroup',                # Control groups to which the process belongs
+      'smaps'                  # Process memory size for all mapped files
     ]
 
     public
@@ -199,48 +202,51 @@ module Sys
 
         stat = stat.split
 
-        struct.pid         = stat[0].to_i
-        struct.comm        = stat[1].tr('()','') # Remove parens
-        struct.state       = stat[2]
-        struct.ppid        = stat[3].to_i
-        struct.pgrp        = stat[4].to_i
-        struct.session     = stat[5].to_i
-        struct.tty_nr      = stat[6].to_i
-        struct.tpgid       = stat[7].to_i
-        struct.flags       = stat[8].to_i
-        struct.minflt      = stat[9].to_i
-        struct.cminflt     = stat[10].to_i
-        struct.majflt      = stat[11].to_i
-        struct.cmajflt     = stat[12].to_i
-        struct.utime       = stat[13].to_i
-        struct.stime       = stat[14].to_i
-        struct.cutime      = stat[15].to_i
-        struct.cstime      = stat[16].to_i
-        struct.priority    = stat[17].to_i
-        struct.nice        = stat[18].to_i
-        struct.num_threads = stat[19].to_i
-        struct.itrealvalue = stat[20].to_i
-        struct.starttime   = stat[21].to_i
-        struct.vsize       = stat[22].to_i
-        struct.rss         = stat[23].to_i
-        struct.rlim        = stat[24].to_i # Old name for backwards compatibility
-        struct.rsslim      = stat[24].to_i
-        struct.startcode   = stat[25].to_i
-        struct.endcode     = stat[26].to_i
-        struct.startstack  = stat[27].to_i
-        struct.kstkesp     = stat[28].to_i
-        struct.kstkeip     = stat[29].to_i
-        struct.signal      = stat[30].to_i
-        struct.blocked     = stat[31].to_i
-        struct.sigignore   = stat[32].to_i
-        struct.sigcatch    = stat[33].to_i
-        struct.wchan       = stat[34].to_i
-        struct.nswap       = stat[35].to_i
-        struct.cnswap      = stat[36].to_i
-        struct.exit_signal = stat[37].to_i
-        struct.processor   = stat[38].to_i
-        struct.rt_priority = stat[39].to_i
-        struct.policy      = stat[40].to_i
+        struct.pid                   = stat[0].to_i
+        struct.comm                  = stat[1].tr('()','') # Remove parens
+        struct.state                 = stat[2]
+        struct.ppid                  = stat[3].to_i
+        struct.pgrp                  = stat[4].to_i
+        struct.session               = stat[5].to_i
+        struct.tty_nr                = stat[6].to_i
+        struct.tpgid                 = stat[7].to_i
+        struct.flags                 = stat[8].to_i
+        struct.minflt                = stat[9].to_i
+        struct.cminflt               = stat[10].to_i
+        struct.majflt                = stat[11].to_i
+        struct.cmajflt               = stat[12].to_i
+        struct.utime                 = stat[13].to_i
+        struct.stime                 = stat[14].to_i
+        struct.cutime                = stat[15].to_i
+        struct.cstime                = stat[16].to_i
+        struct.priority              = stat[17].to_i
+        struct.nice                  = stat[18].to_i
+        struct.num_threads           = stat[19].to_i
+        struct.itrealvalue           = stat[20].to_i
+        struct.starttime             = stat[21].to_i
+        struct.vsize                 = stat[22].to_i
+        struct.rss                   = stat[23].to_i
+        struct.rlim                  = stat[24].to_i # Old name for backwards compatibility
+        struct.rsslim                = stat[24].to_i
+        struct.startcode             = stat[25].to_i
+        struct.endcode               = stat[26].to_i
+        struct.startstack            = stat[27].to_i
+        struct.kstkesp               = stat[28].to_i
+        struct.kstkeip               = stat[29].to_i
+        struct.signal                = stat[30].to_i
+        struct.blocked               = stat[31].to_i
+        struct.sigignore             = stat[32].to_i
+        struct.sigcatch              = stat[33].to_i
+        struct.wchan                 = stat[34].to_i
+        struct.nswap                 = stat[35].to_i
+        struct.cnswap                = stat[36].to_i
+        struct.exit_signal           = stat[37].to_i
+        struct.processor             = stat[38].to_i
+        struct.rt_priority           = stat[39].to_i
+        struct.policy                = stat[40].to_i
+        struct.delayacct_blkio_ticks = stat[41].to_i
+        struct.guest_time            = stat[42].to_i
+        struct.cguest_time           = stat[43].to_i
 
         # Get /proc/<pid>/status information (name, uid, euid, gid, egid)
         begin

--- a/spec/sys_proctable_linux_spec.rb
+++ b/spec/sys_proctable_linux_spec.rb
@@ -13,7 +13,7 @@ describe Sys::ProcTable do
       cmdline cwd environ exe fd root pid name uid euid gid egid comm state ppid pgrp
       session tty_nr tpgid flags minflt cminflt majflt cmajflt utime
       stime cutime cstime priority nice num_threads itrealvalue starttime vsize
-      rss rlim startcode endcode startstack kstkesp kstkeip signal blocked
+      rss rlim rsslim startcode endcode startstack kstkesp kstkeip signal blocked
       sigignore sigcatch wchan nswap cnswap exit_signal processor rt_priority
       policy pctcpu pctmem nlwp cgroup smaps
     ]
@@ -172,9 +172,10 @@ describe Sys::ProcTable do
       expect(subject.rss).to be_kind_of(Numeric)
     end
 
-    it "contains an rlim member and returns the expected value" do
-      expect(subject).to respond_to(:rlim)
-      expect(subject.rlim).to be_kind_of(Numeric)
+    it "contains an rsslim member and returns the expected value" do
+      expect(subject).to respond_to(:rsslim)
+      expect(subject.rsslim).to be_kind_of(Numeric)
+      expect(subject.rsslim).to eq(subject.rlim)
     end
 
     it "contains an startcode member and returns the expected value" do

--- a/spec/sys_proctable_linux_spec.rb
+++ b/spec/sys_proctable_linux_spec.rb
@@ -15,7 +15,7 @@ describe Sys::ProcTable do
       stime cutime cstime priority nice num_threads itrealvalue starttime vsize
       rss rlim rsslim startcode endcode startstack kstkesp kstkeip signal blocked
       sigignore sigcatch wchan nswap cnswap exit_signal processor rt_priority
-      policy pctcpu pctmem nlwp cgroup smaps
+      policy delayacct_blkio_ticks guest_time cguest_time pctcpu pctmem nlwp cgroup smaps
     ]
   }
 
@@ -256,6 +256,21 @@ describe Sys::ProcTable do
     it "contains a policy member and returns the expected value" do
       expect(subject).to respond_to(:policy)
       expect(subject.policy).to be_kind_of(Integer)
+    end
+
+    it "contains a delayacct_blkio_ticks member and returns the expected value" do
+      expect(subject).to respond_to(:delayacct_blkio_ticks)
+      expect(subject.delayacct_blkio_ticks).to be_kind_of(Integer)
+    end
+
+    it "contains a guest_time member and returns the expected value" do
+      expect(subject).to respond_to(:guest_time)
+      expect(subject.guest_time).to be_kind_of(Integer)
+    end
+
+    it "contains a cguest_time member and returns the expected value" do
+      expect(subject).to respond_to(:cguest_time)
+      expect(subject.cguest_time).to be_kind_of(Integer)
     end
 
     it "contains a name member and returns the expected value" do


### PR DESCRIPTION
There have been a few fields added since 2.6, so I'm adding them in this PR. Specifically, the fields are `delayacct_blkio_ticks` (2.6.18), `guest_time` and `cguest_time` (2.6.24). For earlier versions those fields will simply be nil.

I'm also creating a synonym for the `rlim` field since that field is now called `rsslim`, though I've kept the old field for backwards compatibility for now.