### PR TITLE
bug with processes name not ASCII

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+/tmp
+*~
+/vendor
+.env.*
+/logs/
+/bin
+/.bundle


### PR DESCRIPTION
Found that occasionally, when experimenting with changing processes names.