### PR TITLE
Skip an environ spec on Big Sur and later (MacOS)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Gemfile.lock

--- a/lib/darwin/sys/proctable.rb
+++ b/lib/darwin/sys/proctable.rb
@@ -330,6 +330,10 @@ module Sys
 
     # Get the command line arguments, as well as the environment settings,
     # for the given PID.
+    #--
+    # Note that on Big Sur and later it seems that you cannot get environment
+    # variable information on spawned processes except in certain circumstances,
+    # e.g. SIP has been disabled, the kernel is in debug mode, etc.
     #
     def self.get_cmd_args_and_env(pid, struct)
       len = FFI::MemoryPointer.new(:size_t)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,8 @@
+require 'rspec'
+require 'rbconfig'
+
+RSpec.configure do |config|
+  if RbConfig::CONFIG['host_os'] =~ /darwin/ && RbConfig::CONFIG['host_os'].split(/\D+/).last.to_i >= 20
+    config.filter_run_excluding(:skip_big_sur)
+  end
+end

--- a/spec/sys_proctable_darwin_spec.rb
+++ b/spec/sys_proctable_darwin_spec.rb
@@ -4,7 +4,7 @@
 # Test suite for the Darwin version of the sys-proctable library. You
 # should run these tests via the 'rake test' task.
 ########################################################################
-require 'rspec'
+require 'spec_helper'
 require 'sys/proctable'
 require_relative 'sys_proctable_all_spec'
 
@@ -110,7 +110,7 @@ describe Sys::ProcTable do
       expect(subject.exe).to eq(`which sleep`.chomp)
     end
 
-    it "contains an environ member and returns the expected value" do
+    it "contains an environ member and returns the expected value", :skip_big_sur => true do
       expect(subject).to respond_to(:environ)
       expect(subject.environ).to be_kind_of(Hash)
       expect(subject.environ['A']).to eq('B')


### PR DESCRIPTION
It seems you can't generally get environment information on subprocesses as of Big Sur and later. So this PR adds a spec filter so that one of the specs is skipped on Big Sur or later. I also added a comment to the source file.

Addresses https://github.com/djberg96/sys-proctable/issues/89