### PR TITLE
Rubocop updates for Windows

### DIFF
--- a/lib/windows/sys/proctable.rb
+++ b/lib/windows/sys/proctable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'win32ole'
 require 'socket'
 require 'date'
@@ -107,7 +109,7 @@ module Sys
         raise Error, err # Re-raise as ProcTable::Error
       else
         wmi.InstancesOf("Win32_Process").each do |wproc|
-          if pid && !(wproc.ProcessId == pid)
+          if pid && wproc.ProcessId != pid
             next
           end
 

--- a/lib/windows/sys/proctable.rb
+++ b/lib/windows/sys/proctable.rb
@@ -194,6 +194,8 @@ module Sys
       DateTime.parse(str)
     end
 
+    private_class_method :parse_ms_date
+
     #####################################################################
     # There is a bug in win32ole where uint64 types are returned as a
     # String instead of a Fixnum.  This method deals with that for now.
@@ -202,5 +204,7 @@ module Sys
       return nil if str.nil? # Return nil, not 0
       str.to_i
     end
+
+    private_class_method :convert
   end
 end


### PR DESCRIPTION
This mainly gets rid of redundant `return` and `self`, plus a few other minor things.