### PR TITLE
Rubocop cleanup

### DIFF
--- a/lib/darwin/sys/proctable.rb
+++ b/lib/darwin/sys/proctable.rb
@@ -11,11 +11,13 @@ module Sys
     # There is no constructor
     private_class_method :new
 
-    private
-
     PROC_PIDTASKALLINFO = 2
     PROC_PIDTHREADINFO  = 5
     PROC_PIDLISTTHREADS = 6
+
+    private_constant :PROC_PIDTASKALLINFO
+    private_constant :PROC_PIDTHREADINFO
+    private_constant :PROC_PIDLISTTHREADS
 
     CTL_KERN       = 1
     KERN_PROCARGS  = 38
@@ -23,8 +25,17 @@ module Sys
     MAXCOMLEN      = 16
     MAXPATHLEN     = 256
 
+    private_constant :CTL_KERN
+    private_constant :KERN_PROCARGS
+    private_constant :KERN_PROCARGS2
+    private_constant :MAXCOMLEN
+    private_constant :MAXPATHLEN
+
     MAXTHREADNAMESIZE = 64
     PROC_PIDPATHINFO_MAXSIZE = MAXPATHLEN * 4
+
+    private_constant :MAXTHREADNAMESIZE
+    private_constant :PROC_PIDPATHINFO_MAXSIZE
 
     # JRuby/Truffleruby on Mac
     unless defined? FFI::StructLayout::CharArray
@@ -62,6 +73,8 @@ module Sys
       )
     end
 
+    private_constant :ProcBsdInfo
+
     class ProcTaskInfo < FFI::Struct
       layout(
         :pti_virtual_size, :uint64_t,
@@ -85,6 +98,8 @@ module Sys
       )
     end
 
+    private_constant :ProcTaskInfo
+
     class ProcThreadInfo < FFI::Struct
       layout(
         :pth_user_time, :uint64_t,
@@ -101,6 +116,8 @@ module Sys
       )
     end
 
+    private_constant :ProcThreadInfo
+
     # Map the fields from the FFI::Structs to the Sys::ProcTable struct on
     # class load to reduce the amount of objects needing to be generated for
     # each invocation of Sys::ProcTable.ps
@@ -115,6 +132,8 @@ module Sys
       layout(:pbsd, ProcBsdInfo, :ptinfo, ProcTaskInfo)
     end
 
+    private_constant :ProcTaskAllInfo
+
     ffi_lib 'proc'
 
     attach_function :proc_listallpids, %i[pointer int], :int
@@ -123,6 +142,10 @@ module Sys
     ffi_lib FFI::Library::LIBC
 
     attach_function :sysctl, %i[pointer uint pointer pointer pointer size_t], :int
+
+    private_class_method :proc_listallpids
+    private_class_method :proc_pidinfo
+    private_class_method :sysctl
 
     # These mostly mimic the struct members, but we've added a few custom ones as well.
     @fields = %w[
@@ -140,12 +163,14 @@ module Sys
       alias rss resident_size
     end
 
+    private_constant :ProcTableStruct
+
     ThreadInfoStruct = Struct.new("ThreadInfo", :user_time, :system_time,
       :cpu_usage, :policy, :run_state, :flags, :sleep_time, :curpri,
       :priority, :maxpriority, :name
     )
 
-    public
+    private_constant :ThreadInfoStruct
 
     # Returns an array of fields that each ProcTableStruct will contain. This
     # may be useful if you want to know in advance what fields are available

--- a/lib/linux/sys/proctable.rb
+++ b/lib/linux/sys/proctable.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'sys/proctable/version'
 require_relative 'proctable/cgroup_entry'
 require_relative 'proctable/smaps'

--- a/lib/linux/sys/proctable.rb
+++ b/lib/linux/sys/proctable.rb
@@ -122,11 +122,11 @@ module Sys
       array  = block_given? ? nil : []
       struct = nil
 
-      raise TypeError unless pid.is_a?(Numeric) if pid
+      raise TypeError if pid && !pid.is_a?(Numeric)
 
       Dir.foreach("/proc"){ |file|
         next if file =~ /\D/ # Skip non-numeric directories
-        next unless file.to_i == pid if pid
+        next if pid && file.to_i != pid
 
         struct = ProcTableStruct.new
 

--- a/lib/linux/sys/proctable.rb
+++ b/lib/linux/sys/proctable.rb
@@ -204,7 +204,7 @@ module Sys
         stat = stat.split
 
         struct.pid                   = stat[0].to_i
-        struct.comm                  = stat[1].tr('()','') # Remove parens
+        struct.comm                  = stat[1].tr('()', '') # Remove parens
         struct.state                 = stat[2]
         struct.ppid                  = stat[3].to_i
         struct.pgrp                  = stat[4].to_i

--- a/lib/linux/sys/proctable.rb
+++ b/lib/linux/sys/proctable.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'sys/proctable/version'
 require_relative 'proctable/cgroup_entry'
 require_relative 'proctable/smaps'

--- a/lib/linux/sys/proctable.rb
+++ b/lib/linux/sys/proctable.rb
@@ -300,8 +300,6 @@ module Sys
       @fields
     end
 
-    private
-
     # Calculate the percentage of memory usage for the given process.
     #
     def self.get_pctmem(rss)
@@ -310,6 +308,8 @@ module Sys
       rss_total = rss * page_size
       sprintf("%3.2f", (rss_total.to_f / @mem_total) * 100).to_f
     end
+
+    private_class_method :get_pctmem
 
     # Calculate the percentage of CPU usage for the given process.
     #
@@ -320,5 +320,7 @@ module Sys
       stime = (start_time.to_f / hertz) + @boot_time
       sprintf("%3.2f", (utime / 10000.0) / (Time.now.to_i - stime)).to_f
     end
+
+    private_class_method :get_pctcpu
   end
 end

--- a/lib/linux/sys/proctable/cgroup_entry.rb
+++ b/lib/linux/sys/proctable/cgroup_entry.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Sys
   class ProcTable
     # This represents a cgroup entry

--- a/lib/linux/sys/proctable/cgroup_entry.rb
+++ b/lib/linux/sys/proctable/cgroup_entry.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Sys
   class ProcTable
     # This represents a cgroup entry
@@ -21,7 +22,7 @@ module Sys
       def initialize(string)
         @string = string.chomp
         @fields = @string.split(/:/)
-      rescue
+      rescue StandardError
         @fields = []
       end
 
@@ -33,7 +34,7 @@ module Sys
       # Return sets of subsystems bound to the hierarchy
       def subsystems
         @fields[1].split(/,/)
-      rescue
+      rescue StandardError
         []
       end
 

--- a/lib/linux/sys/proctable/smaps.rb
+++ b/lib/linux/sys/proctable/smaps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Sys
   class ProcTable
     # Smaps represents a process' memory size for all mapped files

--- a/lib/linux/sys/proctable/smaps.rb
+++ b/lib/linux/sys/proctable/smaps.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Sys
   class ProcTable
     # Smaps represents a process' memory size for all mapped files
@@ -26,7 +27,18 @@ module Sys
     # Example:
     #
     #   smaps = Smaps.new(123, IO.read("/proc/1234/smaps")
-    #     => #<Sys::ProcTable::Smaps:0x007f8ac5930768 @pid=123, @pss=107000, @rss=368000, @uss=96000, @swap=192000, @vss=136752000>
+    #
+    #   # result
+    #
+    #   #<Sys::ProcTable::Smaps:0x007f8ac5930768
+    #     @pid=123,
+    #     @pss=107000,
+    #     @rss=368000,
+    #     @uss=96000,
+    #     @swap=192000,
+    #     @vss=136752000
+    #   >
+    #
     #   smaps.pss  # => 109568
     #   smaps.rss  # => 376832
     #   smaps.uss  # => 98304

--- a/spec/sys_proctable_darwin_spec.rb
+++ b/spec/sys_proctable_darwin_spec.rb
@@ -119,10 +119,17 @@ RSpec.describe Sys::ProcTable do
   end
 
   context "private constants" do
+    it "makes FFI methods private" do
+      expect(described_class).not_to respond_to(:sysctl)
+      expect(described_class).not_to respond_to(:proc_listallpids)
+      expect(described_class).not_to respond_to(:proc_pidinfo)
+    end
+
     it "makes FFI structs private" do
       expect(described_class.constants).not_to include(:ProcBsdInfo)
       expect(described_class.constants).not_to include(:ProcThreadInfo)
       expect(described_class.constants).not_to include(:ProcTaskInfo)
+      expect(described_class.constants).not_to include(:ProcTaskAllInfo)
     end
 
     it "makes internal constants private" do


### PR DESCRIPTION
For Darwin, this actually makes private things private that were always supposed to be private. On Linux it's some stylistic cleanup suggested by rubocop.