### PR TITLE
Update spec to skip catalina or later

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ require 'rspec'
 require 'rbconfig'
 
 RSpec.configure do |config|
-  if RbConfig::CONFIG['host_os'] =~ /darwin/ && RbConfig::CONFIG['host_os'].split(/\D+/).last.to_i >= 20
-    config.filter_run_excluding(:skip_big_sur)
+  if RbConfig::CONFIG['host_os'] =~ /darwin/ && RbConfig::CONFIG['host_os'].split(/\D+/).last.to_i >= 19
+    config.filter_run_excluding(:skip_catalina_or_later)
   end
 end

--- a/spec/sys_proctable_darwin_spec.rb
+++ b/spec/sys_proctable_darwin_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe Sys::ProcTable do
       expect(subject.exe).to eq(`which sleep`.chomp)
     end
 
-    it "contains an environ member and returns the expected value", :skip_big_sur => true do
+    it "contains an environ member and returns the expected value", :skip_catalina_or_later => true do
       expect(subject).to respond_to(:environ)
       expect(subject.environ).to be_kind_of(Hash)
       expect(subject.environ['A']).to eq('B')


### PR DESCRIPTION
It appears that Apple backported their security rules regarding environment variables on spawned processes to Catalina, as the github actions recently started to fail.