### PR TITLE
Remove spec helper, just skip environ test on mac

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,0 @@
-require 'rspec'
-require 'rbconfig'
-
-RSpec.configure do |config|
-  if RbConfig::CONFIG['host_os'] =~ /darwin/ && RbConfig::CONFIG['host_os'].split(/\D+/).last.to_i >= 20
-    config.filter_run_excluding(:skip_big_sur)
-  end
-end

--- a/spec/sys_proctable_darwin_spec.rb
+++ b/spec/sys_proctable_darwin_spec.rb
@@ -4,7 +4,6 @@
 # Test suite for the Darwin version of the sys-proctable library. You
 # should run these tests via the 'rake test' task.
 ########################################################################
-require 'spec_helper'
 require 'sys/proctable'
 require_relative 'sys_proctable_all_spec'
 
@@ -110,7 +109,8 @@ RSpec.describe Sys::ProcTable do
       expect(subject.exe).to eq(`which sleep`.chomp)
     end
 
-    it "contains an environ member and returns the expected value", :skip_big_sur => true do
+    it "contains an environ member and returns the expected value" do
+      skip "It appears to no longer be possible to get environ on spawned processes on Catalina or later in most cases"
       expect(subject).to respond_to(:environ)
       expect(subject.environ).to be_kind_of(Hash)
       expect(subject.environ['A']).to eq('B')


### PR DESCRIPTION
It looks like whatever security Apple had in place regarding environ on spawned processes was backported to Catalina, rendering that spec moot. So, let's remove the spec_helper.rb for now since checking for Big Sur was its only purpose, and just skip the test.