### PR TITLE
Add 3.0, JRuby and Truffleruby to workflow

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,8 +25,13 @@ jobs:
   test:
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7']
+        ruby-version: ['2.6', '2.7', '3.0', 'jruby', 'truffleruby']
         platform: [ubuntu-latest, macos-latest, windows-latest]
+        exclude:
+          - ruby-version: truffleruby
+            platform: windows-latest
+          - ruby-version: jruby
+            platform: windows-latest
     runs-on: ${{ matrix.platform }}
 
     steps:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0', 'jruby', 'truffleruby']
+        ruby-version: [2.6, 2.7, 3.0, jruby, truffleruby]
         platform: [ubuntu-latest, macos-latest, windows-latest]
         exclude:
           - ruby-version: truffleruby

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -24,6 +24,7 @@ on:
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         ruby-version: ['2.6', '2.7', '3.0', 'jruby', 'truffleruby']
         platform: [ubuntu-latest, macos-latest, windows-latest]

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -33,6 +33,9 @@ jobs:
             platform: windows-latest
           - ruby-version: jruby
             platform: windows-latest
+          - ruby-version: 3.0
+            platform: windows-latest
+    runs-on: ${{ matrix.platform }}
     runs-on: ${{ matrix.platform }}
 
     steps:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,6 @@
+require 'rspec'
+require 'sys-proctable'
+
+RSpec.configure do |config|
+  config.filter_run_excluding(:jruby) if RUBY_PLATFORM == 'java'
+end

--- a/spec/sys_proctable_darwin_spec.rb
+++ b/spec/sys_proctable_darwin_spec.rb
@@ -4,7 +4,7 @@
 # Test suite for the Darwin version of the sys-proctable library. You
 # should run these tests via the 'rake test' task.
 ########################################################################
-require 'sys/proctable'
+require 'spec_helper'
 require_relative 'sys_proctable_all_spec'
 
 RSpec.describe Sys::ProcTable do
@@ -98,7 +98,7 @@ RSpec.describe Sys::ProcTable do
       expect(subject.cmdline).to eq('sleep 60')
     end
 
-    it "returns a string with the expected arguments for the cmdline member" do
+    it "returns a string with the expected arguments for the cmdline member", :skip => :jruby do
       ptable = Sys::ProcTable.ps(pid: @pid2)
       expect(ptable.cmdline).to eq('ruby -Ilib -e sleep \'120\'.to_i -- foo bar')
     end


### PR DESCRIPTION
But skip Windows for Truffleruby and JRuby for now.