### PR TITLE
Spec cleanup

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -51,7 +51,7 @@ end
 
 desc 'Run the test suite for the sys-proctable library'
 RSpec::Core::RakeTask.new(:spec) do |t|
-  t.pattern = ['spec/sys_proctable_all_spec.rb']
+  t.pattern = ['spec/sys_proctable_all_spec.rb', 'spec/sys_top_spec.rb']
 
   case CONFIG['host_os']
     when /aix/i

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'rspec'
 require 'sys-proctable'
+require 'sys-top'
 
 RSpec.configure do |config|
   config.filter_run_excluding(:jruby) if RUBY_PLATFORM == 'java'

--- a/spec/sys_proctable_aix_spec.rb
+++ b/spec/sys_proctable_aix_spec.rb
@@ -2,13 +2,11 @@
 # sys_proctable_aix_spec.rb
 #
 # Test suite for the AIX version of the sys-proctable library. You
-# should run these tests via the 'rake test' task.
+# should run these tests via the 'rake spec' task.
 #######################################################################
-require 'rspec'
-require 'sys/proctable'
-require_relative 'sys_proctable_all_spec'
+require 'spec_helper'
 
-describe Sys::ProcTable do
+RSpec.describe Sys::ProcTable do
   let(:fields){
     %w[
         addr argc argv bindpro cid clname cmd_args cmdline cwd egid environ

--- a/spec/sys_proctable_all_spec.rb
+++ b/spec/sys_proctable_all_spec.rb
@@ -4,11 +4,9 @@
 # Test suite for methods common to all platforms. Generally speaking
 # you should run these specs using the 'rake test' task.
 #######################################################################
-require 'rspec'
-require 'sys/proctable'
-require_relative 'sys_top_spec'
+require 'spec_helper'
 
-describe Sys::ProcTable do
+RSpec.describe Sys::ProcTable do
   let(:windows) { File::ALT_SEPARATOR }
 
   before(:all) do

--- a/spec/sys_proctable_all_spec.rb
+++ b/spec/sys_proctable_all_spec.rb
@@ -6,7 +6,7 @@
 #######################################################################
 require 'spec_helper'
 
-RSpec.describe Sys::ProcTable do
+RSpec.describe 'common' do
   let(:windows) { File::ALT_SEPARATOR }
 
   before(:all) do
@@ -25,64 +25,64 @@ RSpec.describe Sys::ProcTable do
 
   context "fields" do
     it "has a fields singleton method" do
-      expect(described_class).to respond_to(:fields)
+      expect(Sys::ProcTable).to respond_to(:fields)
     end
 
     it "returns the expected data type for the fields singleton method" do
-      expect(described_class.fields).to be_kind_of(Array)
-      expect(described_class.fields.first).to be_kind_of(String)
+      expect(Sys::ProcTable.fields).to be_kind_of(Array)
+      expect(Sys::ProcTable.fields.first).to be_kind_of(String)
     end
   end
 
   context "ps" do
     it "defines a ps singleton method" do
-      expect(described_class).to respond_to(:ps)
+      expect(Sys::ProcTable).to respond_to(:ps)
     end
 
     it "allows a pid option as an argument" do
-      expect{ described_class.ps(pid: 0) }.to_not raise_error
+      expect{ Sys::ProcTable.ps(pid: 0) }.to_not raise_error
     end
 
     it "allows the pid to be nil" do
-      expect{ described_class.ps(pid: nil) }.to_not raise_error
-      expect(described_class.ps(pid: nil)).to be_kind_of(Array)
+      expect{ Sys::ProcTable.ps(pid: nil) }.to_not raise_error
+      expect(Sys::ProcTable.ps(pid: nil)).to be_kind_of(Array)
     end
 
     it "returns expected results with no arguments" do
-      expect(described_class.ps).to be_kind_of(Array)
+      expect(Sys::ProcTable.ps).to be_kind_of(Array)
     end
 
     it "returns expected results with a pid argument" do
-      expect(described_class.ps(pid: @pid)).to be_kind_of(Struct::ProcTableStruct)
+      expect(Sys::ProcTable.ps(pid: @pid)).to be_kind_of(Struct::ProcTableStruct)
     end
 
     it "returns nil if the process does not exist" do
-      expect(described_class.ps(pid: 999999999)).to be_nil
+      expect(Sys::ProcTable.ps(pid: 999999999)).to be_nil
     end
 
     it "returns nil in block form whether or not a pid was provided" do
-      expect(described_class.ps{}).to be_nil
-      expect(described_class.ps(pid: 999999999){}).to be_nil
+      expect(Sys::ProcTable.ps{}).to be_nil
+      expect(Sys::ProcTable.ps(pid: 999999999){}).to be_nil
     end
 
     it "returns frozen structs" do
-      expect(described_class.ps.first.frozen?).to eql(true)
+      expect(Sys::ProcTable.ps.first.frozen?).to eql(true)
     end
 
     it "expects a numeric pid argument if present" do
-      expect{ described_class.ps(pid: 'vim') }.to raise_error(TypeError)
+      expect{ Sys::ProcTable.ps(pid: 'vim') }.to raise_error(TypeError)
     end
 
     it "accepts keyword arguments only" do
-      expect{ described_class.ps(0, 'localhost') }.to raise_error(ArgumentError)
+      expect{ Sys::ProcTable.ps(0, 'localhost') }.to raise_error(ArgumentError)
     end
 
     it "disables the traditional constructor" do
-      expect{ described_class.new }.to raise_error(NoMethodError)
+      expect{ Sys::ProcTable.new }.to raise_error(NoMethodError)
     end
 
     it "works within a thread" do
-      expect{ Thread.new{ described_class.ps }.value }.to_not raise_error
+      expect{ Thread.new{ Sys::ProcTable.ps }.value }.to_not raise_error
     end
   end
 end

--- a/spec/sys_proctable_darwin_spec.rb
+++ b/spec/sys_proctable_darwin_spec.rb
@@ -5,7 +5,6 @@
 # should run these tests via the 'rake test' task.
 ########################################################################
 require 'spec_helper'
-require_relative 'sys_proctable_all_spec'
 
 RSpec.describe Sys::ProcTable do
   let(:fields){

--- a/spec/sys_proctable_darwin_spec.rb
+++ b/spec/sys_proctable_darwin_spec.rb
@@ -6,7 +6,7 @@
 ########################################################################
 require 'spec_helper'
 
-RSpec.describe Sys::ProcTable do
+RSpec.describe Sys::ProcTable, :darwin do
   let(:fields){
     %w[
       flags status xstatus pid ppid uid gid ruid rgid svuid svgid rfu1 comm

--- a/spec/sys_proctable_freebsd_spec.rb
+++ b/spec/sys_proctable_freebsd_spec.rb
@@ -2,13 +2,11 @@
 # sys_proctable_freebsd_rspec.rb
 #
 # Test suite for FreeBSD for the sys-proctable library.
-# You should run these tests via 'rake test'.
+# You should run these tests via the 'rake spec' task.
 ################################################################
-require 'rspec'
-require 'sys/proctable'
-require_relative 'sys_proctable_all_spec'
+require 'spec_helper'
 
-describe Sys::ProcTable do
+RSpec.describe Sys::ProcTable do
   let(:fields){
     %w[
       pid ppid pgid tpgid sid tsid jobc uid ruid rgid

--- a/spec/sys_proctable_linux_spec.rb
+++ b/spec/sys_proctable_linux_spec.rb
@@ -2,13 +2,11 @@
 # sys_proctable_linux_spec.rb
 #
 # Test suite for the Linux version of the sys-proctable library. You
-# should run these tests via the 'rake test' task.
+# should run these tests via the 'rake spec' task.
 #######################################################################
-require 'rspec'
-require 'sys/proctable'
-require_relative 'sys_proctable_all_spec'
+require 'spec_helper'
 
-describe Sys::ProcTable do
+RSpec.describe Sys::ProcTable do
   let(:fields){ %w[
       cmdline cwd environ exe fd root pid name uid euid gid egid comm state ppid pgrp
       session tty_nr tpgid flags minflt cminflt majflt cmajflt utime

--- a/spec/sys_proctable_sunos_spec.rb
+++ b/spec/sys_proctable_sunos_spec.rb
@@ -2,13 +2,11 @@
 # sys_proctable_sunos_spec.rb
 #
 # Test suite for sys-proctable for SunOS/Solaris. This should be run
-# run via the 'rake test' task.
+# run via the 'rake spec' task.
 #######################################################################
-require 'rspec'
-require 'sys/proctable'
-require_relative 'sys_proctable_all_spec'
+require 'spec_helper'
 
-describe Sys::ProcTable do
+RSpec.describe Sys::ProcTable do
   let(:fields){
     %w[
         flag nlwp pid ppid pgid sid uid euid gid egid addr size

--- a/spec/sys_proctable_windows_spec.rb
+++ b/spec/sys_proctable_windows_spec.rb
@@ -2,12 +2,10 @@
 # sys_proctable_windows_spec.rb
 #
 # Test suite for the sys-proctable library for MS Windows. This should be
-# run via the 'rake test' task.
+# run via the 'rake spec' task.
 ############################################################################
-require 'rspec'
-require 'sys-proctable'
+require 'spec_helper'
 require 'socket'
-require_relative 'sys_proctable_all_spec'
 
 describe Sys::ProcTable do
   let(:hostname) { Socket.gethostname }

--- a/spec/sys_top_spec.rb
+++ b/spec/sys_top_spec.rb
@@ -3,10 +3,9 @@
 #
 # Test suite for the sys-top library that is included with this distribution.
 ##############################################################################
-require 'rspec'
-require 'sys/top'
+require 'spec_helper'
 
-describe Sys::Top do
+RSpec.describe Sys::Top do
   context "constants" do
     it "sets the version to the expected value" do
       expect(Sys::Top::VERSION).to eql('1.0.5')
@@ -15,7 +14,7 @@ describe Sys::Top do
 
   context "top" do
     it "defines a top method" do
-      expect(described_class).to respond_to(:top) 
+      expect(described_class).to respond_to(:top)
     end
 
     it "returns an array" do


### PR DESCRIPTION
This is step 1 towards using shared examples, and in the process I realized that the common specs were actually being loaded and run twice, oops. So, this not only ends that, it also does some minor updates to use explicit `RSpec` at the toplevel, and some comment updates.