### PR TITLE
Use kvm_openfiles instead of kvm_open for BSD

### DIFF
--- a/lib/bsd/sys/freebsd/sys/proctable.rb
+++ b/lib/bsd/sys/freebsd/sys/proctable.rb
@@ -50,12 +50,14 @@ module Sys
     #
     def self.ps(**kwargs)
       pid = kwargs[:pid]
+      errbuf = 0.chr * POSIX2_LINE_MAX
 
       begin
-        kd = kvm_open(nil, nil, nil, 0, nil)
+        kd = kvm_openfiles(nil, nil, nil, 0, errbuf)
 
         if kd.null?
-          raise SystemCallError.new('kvm_open', FFI.errno)
+          error = errbuf.split(0.chr).first
+          raise SystemCallError.new("kvm_openfiles - #{error}", FFI.errno)
         end
 
         ptr = FFI::MemoryPointer.new(:int) # count

--- a/lib/bsd/sys/freebsd/sys/proctable/constants.rb
+++ b/lib/bsd/sys/freebsd/sys/proctable/constants.rb
@@ -1,6 +1,7 @@
 module Sys
   module ProcTableConstants
     POSIX_ARG_MAX = 4096
+    POSIX2_LINE_MAX = 2048
 
     KERN_PROC_PID  = 1
     KERN_PROC_PROC = 8

--- a/lib/bsd/sys/freebsd/sys/proctable/functions.rb
+++ b/lib/bsd/sys/freebsd/sys/proctable/functions.rb
@@ -6,7 +6,7 @@ module Sys
     ffi_lib :kvm
 
     attach_function :devname, [:dev_t, :mode_t], :string
-    attach_function :kvm_open, [:string, :string, :string, :int, :string], :pointer
+    attach_function :kvm_openfiles, [:string, :string, :string, :int, :buffer_out], :pointer
     attach_function :kvm_close, [:pointer], :int
     attach_function :kvm_getprocs, [:pointer, :int, :int, :pointer], :pointer
     attach_function :kvm_getargv, [:pointer, :pointer, :int], :pointer


### PR DESCRIPTION
The original `kvm_open` was apparently for Sun compatibility only. Modern BSD systems are supposed to use `kvm_open2` or `kvm_openfiles`. I've opted for the latter.