### PR TITLE
[darwin] Eliminate warning

### DIFF
--- a/lib/darwin/sys/proctable.rb
+++ b/lib/darwin/sys/proctable.rb
@@ -417,7 +417,7 @@ module Sys
         argc = array.size
       end
 
-      cmdline = ''
+      cmdline = +''
 
       # Extract the full command line and its arguments from the array
       argc.times do


### PR DESCRIPTION
This PR eliminates following warning from darwin's proctable implementation.

```
warning: literal string will be frozen in the future
```

Other implemantation may need similar fix