### PR TITLE
Replace File.exists? with File.exist?

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,7 @@ task :install do
   file = nil
   dir  = File.join(CONFIG['sitelibdir'], 'sys')
 
-  Dir.mkdir(dir) unless File.exists?(dir)
+  Dir.mkdir(dir) unless File.exist?(dir)
 
   case CONFIG['host_os']
     when /mswin|win32|msdos|cygwin|mingw|windows/i


### PR DESCRIPTION
## Summary

- `File.exists?` was deprecated in Ruby 2.7 and removed in Ruby 3.2
- The `rake install` task raises `NoMethodError` on any Ruby >= 3.2 because of this
- Switches to `File.exist?` which has been available since Ruby 1.0

## Test plan

- [ ] `rake install` no longer errors on Ruby 3.2+
- [ ] Existing test suite passes (`bundle exec rake`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)