### PR TITLE
Fix kB-to-bytes conversion in Linux smaps parsing

### DIFF
--- a/lib/linux/sys/proctable/smaps.rb
+++ b/lib/linux/sys/proctable/smaps.rb
@@ -114,15 +114,15 @@ module Sys
       def parse_smaps_line(line)
         case line
           when /^Pss:\s+?(\d+)/
-            @pss += Regexp.last_match[1].to_i * 1000
+            @pss += Regexp.last_match[1].to_i * 1024
           when /^Rss:\s+?(\d+)/
-            @rss += Regexp.last_match[1].to_i * 1000
+            @rss += Regexp.last_match[1].to_i * 1024
           when /^Size:\s+?(\d+)/
-            @vss += Regexp.last_match[1].to_i * 1000
+            @vss += Regexp.last_match[1].to_i * 1024
           when /^Swap:\s+?(\d+)/
-            @swap += Regexp.last_match[1].to_i * 1000
+            @swap += Regexp.last_match[1].to_i * 1024
           when /^Private_(Clean|Dirty):\s+?(\d+)/
-            @uss += Regexp.last_match[2].to_i * 1000
+            @uss += Regexp.last_match[2].to_i * 1024
         end
       end
     end


### PR DESCRIPTION
## Summary

- The smaps parser multiplied kB values from `/proc/[pid]/smaps` by 1000 to convert to bytes
- kB in `/proc` means kibibytes (1024 bytes), not 1000
- This caused all smaps memory metrics (`pss`, `rss`, `uss`, `vss`, `swap`) to be underreported by approximately 2.4%

## Test plan

- [ ] Existing test suite passes (`bundle exec rake`)
- [ ] Smaps memory values are now ~2.4% higher than before (consistent with actual values)

🤖 Generated with [Claude Code](https://claude.com/claude-code)